### PR TITLE
upgrade graal to 19.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,19 +23,19 @@
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
-      <version>1.0.0-rc9</version>
+      <version>19.1.1</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.oracle.truffle/truffle-api -->
     <dependency>
       <groupId>org.graalvm.truffle</groupId>
       <artifactId>truffle-api</artifactId>
-      <version>1.0.0-rc9</version>
+      <version>19.1.1</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.graalvm.js/js -->
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
-      <version>1.0.0-rc9</version>
+      <version>19.1.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,23 +19,27 @@
     </license>
   </licenses>
 
+  <properties>
+    <graalvm.version>19.1.1</graalvm.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.graalvm.sdk</groupId>
       <artifactId>graal-sdk</artifactId>
-      <version>19.1.1</version>
+      <version>${graalvm.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/com.oracle.truffle/truffle-api -->
     <dependency>
       <groupId>org.graalvm.truffle</groupId>
       <artifactId>truffle-api</artifactId>
-      <version>19.1.1</version>
+      <version>${graalvm.version}</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.graalvm.js/js -->
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
-      <version>19.1.1</version>
+      <version>${graalvm.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/graal/GraalGuestException.java
+++ b/src/main/java/graal/GraalGuestException.java
@@ -1,0 +1,40 @@
+package graal;
+
+import org.graalvm.polyglot.HostAccess;
+
+public class GraalGuestException extends RuntimeException {
+    @HostAccess.Export
+    public final String message;
+    @HostAccess.Export
+    public String stack;
+
+    @HostAccess.Export
+    public GraalGuestException(String message) {
+        super(message);
+        this.message = message;
+        this.setStackTrace();
+    }
+
+    @HostAccess.Export
+    public GraalGuestException(String message, Throwable cause) {
+        super(message, cause);
+        this.message = cause.getMessage();
+        this.setStackTrace();
+    }
+
+    @HostAccess.Export
+    public GraalGuestException(Throwable cause) {
+        super(cause);
+        this.message = cause.getMessage();
+        this.setStackTrace();
+    }
+
+    private void setStackTrace() {
+        StringBuffer buffer = new StringBuffer();
+        for (StackTraceElement e : super.getStackTrace()) {
+            buffer.append(e.toString());
+            buffer.append("<br/>\n");
+        }
+        stack = buffer.toString();
+    }
+}

--- a/src/main/java/graal/GraalGuestException.java
+++ b/src/main/java/graal/GraalGuestException.java
@@ -3,38 +3,36 @@ package graal;
 import org.graalvm.polyglot.HostAccess;
 
 public class GraalGuestException extends RuntimeException {
-    @HostAccess.Export
-    public final String message;
-    @HostAccess.Export
-    public String stack;
+  @HostAccess.Export public final String message;
+  @HostAccess.Export public String stack;
 
-    @HostAccess.Export
-    public GraalGuestException(String message) {
-        super(message);
-        this.message = message;
-        this.setStackTrace();
-    }
+  @HostAccess.Export
+  public GraalGuestException(String message) {
+    super(message);
+    this.message = message;
+    this.setStackTrace();
+  }
 
-    @HostAccess.Export
-    public GraalGuestException(String message, Throwable cause) {
-        super(message, cause);
-        this.message = cause.getMessage();
-        this.setStackTrace();
-    }
+  @HostAccess.Export
+  public GraalGuestException(String message, Throwable cause) {
+    super(message, cause);
+    this.message = cause.getMessage();
+    this.setStackTrace();
+  }
 
-    @HostAccess.Export
-    public GraalGuestException(Throwable cause) {
-        super(cause);
-        this.message = cause.getMessage();
-        this.setStackTrace();
-    }
+  @HostAccess.Export
+  public GraalGuestException(Throwable cause) {
+    super(cause);
+    this.message = cause.getMessage();
+    this.setStackTrace();
+  }
 
-    private void setStackTrace() {
-        StringBuffer buffer = new StringBuffer();
-        for (StackTraceElement e : super.getStackTrace()) {
-            buffer.append(e.toString());
-            buffer.append("<br/>\n");
-        }
-        stack = buffer.toString();
+  private void setStackTrace() {
+    StringBuffer buffer = new StringBuffer();
+    for (StackTraceElement e : super.getStackTrace()) {
+      buffer.append(e.toString());
+      buffer.append("<br/>\n");
     }
+    stack = buffer.toString();
+  }
 }

--- a/src/test/java/graal/ModuleTest.java
+++ b/src/test/java/graal/ModuleTest.java
@@ -218,7 +218,7 @@ public class ModuleTest {
     assertEquals("nmfile1", require.require("./nmfile1").getMember("nmfile1").asString());
   }
 
-  @Test(expected = PolyglotException.class)
+  @Test(expected = GraalGuestException.class)
   public void itDoesNotUseModulesOutsideOfNodeModulesForNonPrefixedNames() throws Throwable {
     require.require("file1.js");
   }
@@ -260,27 +260,27 @@ public class ModuleTest {
     assertEquals("file1", require.require("./file1").getMember("file1").asString());
   }
 
-  @Test(expected = PolyglotException.class)
+  @Test(expected = GraalGuestException.class)
   public void itThrowsAnExceptionIfFileDoesNotExists() throws Throwable {
     require.require("./invalid");
   }
 
-  @Test(expected = PolyglotException.class)
+  @Test(expected = GraalGuestException.class)
   public void itThrowsAnExceptionIfSubFileDoesNotExists() throws Throwable {
     require.require("./sub1/invalid");
   }
 
-  @Test(expected = PolyglotException.class)
+  @Test(expected = GraalGuestException.class)
   public void itThrowsEnExceptionIfFolderDoesNotExists() throws Throwable {
     require.require("./invalid/file1.js");
   }
 
-  @Test(expected = PolyglotException.class)
+  @Test(expected = GraalGuestException.class)
   public void itThrowsEnExceptionIfSubFolderDoesNotExists() throws Throwable {
     require.require("./sub1/invalid/file1.js");
   }
 
-  @Test(expected = PolyglotException.class)
+  @Test(expected = GraalGuestException.class)
   public void itThrowsAnExceptionIfTryingToGoAboveTheTopLevelFolder() throws Throwable {
     // We need two ".." because otherwise the resolving attempts to load from "node_modules" and
     // ".." validly points to the root folder there.


### PR DESCRIPTION
`mvn install` passes.
I tested this in Transposit locally and made sure it:
- loads a library (I tried underscore.js) successfully
- throws an error that's usable by javascript when you try to load a module that doesn't exist

<img width="321" alt="Screen Shot 2019-08-13 at 11 35 48 AM" src="https://user-images.githubusercontent.com/1447698/62967800-956e9900-bdbe-11e9-9165-89f102807b02.png">
